### PR TITLE
chore(deps): bump to go125

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/loicsikidi/mdbook-sitemap-generator
 
-go 1.24.1
+go 1.25.0
 
 require (
 	github.com/BurntSushi/toml v1.5.0

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,9 @@
 let
-  # golang pinned to 1.24.0
+  # golang pinned to 1.25.0
   nixpkgs =
     fetchTarball
     # go to https://www.nixhub.io/packages/go to the list of available versions
-    "https://github.com/NixOS/nixpkgs/archive/2d068ae5c6516b2d04562de50a58c682540de9bf.tar.gz";
+    "https://github.com/NixOS/nixpkgs/archive/f4b140d5b253f5e2a1ff4e5506edbf8267724bde.tar.gz";
   pkgs = import nixpkgs {
     config = {};
     overlays = [];


### PR DESCRIPTION
Note: go 1.24 is in end-of-life since 11 Feb 2026